### PR TITLE
Fix Copyright Placeholder in LICENSE File

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2025 Laurie Kirk (LaurieWired)
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.


### PR DESCRIPTION
Hello Ms. Laurie,

I reviewed the project after watching your video and noticed a small issue in the LICENSE file.

The Apache 2.0 license template was present but the copyright line was still using placeholder values: `Copyright [yyyy] [copyright holder's name]`

I've replaced this line with: `Copyright 2025 Laurie Kirk (LaurieWired)` to make the license legally valid and unambiguous for downstream users. I thought it might be good to highlight your Github username. I'm not sure.

---

## Note on License Compliance

According to Section 4 of the Apache License 2.0, each source file should ideally include a license header. For example:

```cpp
/*
 * Copyright 2025 Laurie Kirk
 *
 * Licensed under the Apache License, Version 2.0 (the “License”);
 * you may not use this file except in compliance with the License.
 * You may obtain a copy of the License at
 *
 *     http://www.apache.org/licenses/LICENSE-2.0
 *
 * Unless required by applicable law or agreed to in writing, software
 * distributed under the License is distributed on an “AS IS” BASIS,
 * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 * See the License for the specific language governing permissions and
 * limitations under the License.
 */
```

Adding such headers ensures full license compliance and prevents ambiguities when individual files are reused.

If you prefer a follow-up PR on this issue or have any other suggestions for changes you think we could make, please let me know.

Best regards,